### PR TITLE
staking ratio as percents

### DIFF
--- a/api/render/info.go
+++ b/api/render/info.go
@@ -5,9 +5,12 @@ import (
 	"github.com/bullblock-io/tezTracker/models"
 )
 
+const annualYield = 7.45
+
 // Info renders price info into OpenAPI model.
 func Info(mi models.MarketInfo, ratio float64) *genModels.Info {
 	p := mi.GetPrice()
 	p24 := mi.GetPriceChange()
-	return &genModels.Info{Price: &p, Price24hChange: &p24, StakingRatio: ratio * 100}
+	ratioInPercent := ratio * 100
+	return &genModels.Info{Price: &p, Price24hChange: &p24, StakingRatio: &ratioInPercent, AnnualYield: annualYield}
 }

--- a/api/render/info.go
+++ b/api/render/info.go
@@ -9,5 +9,5 @@ import (
 func Info(mi models.MarketInfo, ratio float64) *genModels.Info {
 	p := mi.GetPrice()
 	p24 := mi.GetPriceChange()
-	return &genModels.Info{Price: &p, Price24hChange: &p24, StakingRatio: ratio}
+	return &genModels.Info{Price: &p, Price24hChange: &p24, StakingRatio: ratio * 100}
 }

--- a/gen/models/info.go
+++ b/gen/models/info.go
@@ -17,6 +17,9 @@ import (
 // swagger:model Info
 type Info struct {
 
+	// Expected annual return in percents.
+	AnnualYield float64 `json:"annual_yield,omitempty"`
+
 	// price
 	// Required: true
 	Price *float64 `json:"price"`
@@ -25,8 +28,10 @@ type Info struct {
 	// Required: true
 	Price24hChange *float64 `json:"price_24h_change"`
 
-	// staking ratio
-	StakingRatio float64 `json:"staking_ratio,omitempty"`
+	// Staking ratio in percents (0-100).
+	// Maximum: 100
+	// Minimum: 0
+	StakingRatio *float64 `json:"staking_ratio,omitempty"`
 }
 
 // Validate validates this info
@@ -38,6 +43,10 @@ func (m *Info) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validatePrice24hChange(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateStakingRatio(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -59,6 +68,23 @@ func (m *Info) validatePrice(formats strfmt.Registry) error {
 func (m *Info) validatePrice24hChange(formats strfmt.Registry) error {
 
 	if err := validate.Required("price_24h_change", "body", m.Price24hChange); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *Info) validateStakingRatio(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.StakingRatio) { // not required
+		return nil
+	}
+
+	if err := validate.Minimum("staking_ratio", "body", float64(*m.StakingRatio), 0, false); err != nil {
+		return err
+	}
+
+	if err := validate.Maximum("staking_ratio", "body", float64(*m.StakingRatio), 100, false); err != nil {
 		return err
 	}
 

--- a/gen/restapi/embedded_spec.go
+++ b/gen/restapi/embedded_spec.go
@@ -2161,6 +2161,10 @@ func init() {
         "price_24h_change"
       ],
       "properties": {
+        "annual_yield": {
+          "description": "Expected annual return in percents.",
+          "type": "number"
+        },
         "price": {
           "type": "number"
         },
@@ -2168,7 +2172,9 @@ func init() {
           "type": "number"
         },
         "staking_ratio": {
-          "type": "number"
+          "description": "Staking ratio in percents (0-100).",
+          "type": "number",
+          "maximum": 100
         }
       }
     },
@@ -4660,6 +4666,10 @@ func init() {
         "price_24h_change"
       ],
       "properties": {
+        "annual_yield": {
+          "description": "Expected annual return in percents.",
+          "type": "number"
+        },
         "price": {
           "type": "number"
         },
@@ -4667,7 +4677,10 @@ func init() {
           "type": "number"
         },
         "staking_ratio": {
-          "type": "number"
+          "description": "Staking ratio in percents (0-100).",
+          "type": "number",
+          "maximum": 100,
+          "minimum": 0
         }
       }
     },

--- a/swagger/swagger.yml
+++ b/swagger/swagger.yml
@@ -1379,7 +1379,13 @@ definitions:
       price_24h_change:
         type: number
       staking_ratio:
+        description: Staking ratio in percents (0-100).
         type: number
+        minimum: 0
+        maximum: 100
+      annual_yield:
+        type: number
+        description: Expected annual return in percents.
     required:
       - price
       - price_24h_change


### PR DESCRIPTION
Info endpoint has price_24h_change in percents and staking ratio is also in percents now.